### PR TITLE
Updating the wiktionary to the newer version

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -88,7 +88,7 @@ kiwix_directory_mode: "0755"
 
 kiwix_version: kiwix-tools_linux-armhf-3.4.0
 vikidia_version: vikidia_en_all_nopic_2021-03
-wiktionary_version: wiktionary_en_simple_all_nopic_2022-12
+wiktionary_version: wiktionary_en_simple_all_nopic_2023-01
 
 ansible_host_key_checking: false
 


### PR DESCRIPTION
The old version is not available anymore:
 - https://ftp.nluug.nl/pub/kiwix/zim/wiktionary/wiktionary_en_simple_all_nopic_2022-12.zim