### PR TITLE
Fix for Flexbooks not loading

### DIFF
--- a/ansible/inventory.yml
+++ b/ansible/inventory.yml
@@ -4,7 +4,7 @@ all:
     raspberrypi:
       ansible_user: pi
       ansible_ssh_pass: elimupi
-      ansible_host: 192.168.2.60
+      ansible_host: elimupi
     dockerpi:
       ansible_host: 127.0.0.1
       ansible_port: 5022

--- a/ansible/roles/common/files/kolibri/options.ini
+++ b/ansible/roles/common/files/kolibri/options.ini
@@ -60,6 +60,7 @@ CONTENT_FALLBACK_DIRS = /home/pi/.kolibri/,
 [Deployment]
 URL_PATH_PREFIX = /
 HTTP_PORT = 8080
+ZIP_CONTENT_PORT = 8081
 [Python]
 [HTML5]
 SANDBOX = allow-scripts

--- a/ansible/roles/common/tasks/firewall.yml
+++ b/ansible/roles/common/tasks/firewall.yml
@@ -37,6 +37,18 @@
     - 172.16.0.0/12
     - 192.168.0.0/16
 
+- name: Allow http kolibri zip content
+  community.general.ufw:
+    rule: allow
+    port: '8081'
+    proto: tcp
+    src: '{{ item }}'
+  loop:
+    - fe80::/10
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+
 - name: Allow http Scratch GUI
   community.general.ufw:
     rule: allow


### PR DESCRIPTION
The port for the ZIP content is 8081, but this was being blocked by the firewall and it was not specified in the config of Kolibri taking the port `0` as default. Now it is able to load

<img width="1431" alt="Screen Shot 2023-04-05 at 00 28 05" src="https://user-images.githubusercontent.com/1468785/229936427-ddcadc54-e314-4828-a3a9-302fe26a2877.png">
