### PR TITLE
Adds DNS redirection for when the internet connection is not available and a 404 landing page

### DIFF
--- a/ansible/roles/common/files/check_internet_connection.sh
+++ b/ansible/roles/common/files/check_internet_connection.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# We check against the Google DNS for internet connection, if there is no
+# connection, using Dnsmasq we resolve all the domains to the Elimupi address
+
+# Check against the google DNS
+ping -c 1 8.8.8.8 > /dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    # When the internet connection is down, forward everything to the elimupi address
+    if [ ! -e /etc/dnsmasq.d/custom-dns.conf ]; then
+      echo "Adding local forward"
+      echo -e "address=/#/10.11.0.1\nttl=5" > /etc/dnsmasq.d/custom-dns.conf
+      systemctl restart dnsmasq
+      systemctl restart systemd-resolved
+    fi
+else
+    # We are available, remove the rule
+    if [ -e /etc/dnsmasq.d/custom-dns.conf ]; then
+      echo "Removing local forward"
+      rm /etc/dnsmasq.d/custom-dns.conf
+      systemctl restart dnsmasq
+      systemctl restart systemd-resolved
+    fi
+fi

--- a/ansible/roles/common/files/nginx/elimupi.local
+++ b/ansible/roles/common/files/nginx/elimupi.local
@@ -48,4 +48,6 @@ server {
         #location ~ /\.ht {
         #       deny all;
         #}
+
+	error_page 404 /404.php;
 }

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -45,5 +45,8 @@
 # firewall - setup firewall
 - include_tasks: firewall.yml
 
+# offline_redirection - setup offline redirections
+- include_tasks: offline_redirection.yml
+
 # release file 
 - include_tasks: release.yml

--- a/ansible/roles/common/tasks/offline_redirection.yml
+++ b/ansible/roles/common/tasks/offline_redirection.yml
@@ -1,0 +1,12 @@
+- name: Copy the internet connection check script
+  ansible.builtin.copy:
+    src: "check_internet_connection.sh"
+    dest: "/usr/local/bin/check_internet.sh"
+    mode: "u+x"
+
+- name: Add cron task to check internet connection
+  ansible.builtin.cron:
+    name: "check_internet"
+    minute: "*"
+    job: "/usr/local/bin/check_internet.sh"
+    user: "root"


### PR DESCRIPTION
This is the cleanest way I found to do this.

This PR is adding a new script that constantly runs every minute by cron, it tries to ping the Google DNS and waits for 5 seconds, if the IP is not reachable it adds a rule in dnsmasq that will forward all the DNS resolutions to the Elimupi address with a TTL of 5 seconds.

This should be good enough, but if the connection is flickering the DNS cache of the client may still try to connect to the real IP, but in most of the cases we will have or don't have internet connection more than it flickering.

We are also adding a 404 page to the NGINX config, the page is added in this other PR: https://github.com/DEAN-ngo/ElimuPi-Web-Interface/pull/17