### PR TITLE
Start the X + Firefox when an HDMI device is detected

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -88,7 +88,7 @@ kiwix_directory_mode: "0755"
 
 kiwix_version: kiwix-tools_linux-armhf-3.4.0
 vikidia_version: vikidia_en_all_nopic_2023-03
-wiktionary_version: wiktionary_en_simple_all_nopic_2023-03
+wiktionary_version: wiktionary_en_simple_all_nopic_2023-07
 
 ansible_host_key_checking: false
 

--- a/ansible/roles/common/files/check_internet_connection.sh
+++ b/ansible/roles/common/files/check_internet_connection.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+# We check against the Google DNS for internet connection, if there is no
+# connection, using Dnsmasq we resolve all the domains to the Elimupi address
+
+# Check against the google DNS
+ping -c 1 8.8.8.8 > /dev/null 2>&1
+
+if [ $? -ne 0 ]; then
+    # When the internet connection is down, forward everything to the elimupi address
+    if [ ! -e /etc/dnsmasq.d/custom-dns.conf ]; then
+      echo "Adding local forward"
+      echo -e "address=/#/10.11.0.1\nttl=5" > /etc/dnsmasq.d/custom-dns.conf
+      systemctl restart dnsmasq
+      systemctl restart systemd-resolved
+    fi
+else
+    # We are available, remove the rule
+    if [ -e /etc/dnsmasq.d/custom-dns.conf ]; then
+      echo "Removing local forward"
+      rm /etc/dnsmasq.d/custom-dns.conf
+      systemctl restart dnsmasq
+      systemctl restart systemd-resolved
+    fi
+fi

--- a/ansible/roles/common/files/nginx/elimupi.local
+++ b/ansible/roles/common/files/nginx/elimupi.local
@@ -48,4 +48,6 @@ server {
         #location ~ /\.ht {
         #       deny all;
         #}
+
+	error_page 404 /404.php;
 }

--- a/ansible/roles/common/files/x_server/firefox-autostart.desktop
+++ b/ansible/roles/common/files/x_server/firefox-autostart.desktop
@@ -1,0 +1,5 @@
+[Desktop Entry]
+Name=Firefox Autostart
+Exec=/usr/bin/firefox -new-instance "elimupi.online"
+Type=Application
+X-GNOME-Autostart-enabled=true

--- a/ansible/roles/common/files/x_server/hdmi_connect_script.sh
+++ b/ansible/roles/common/files/x_server/hdmi_connect_script.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# Check the status of HDMI port 1
+status_port1=$(/usr/bin/cat /sys/class/drm/card1/card1-HDMI-A-1/status)
+
+# Check the status of HDMI port 2
+status_port2=$(/usr/bin/cat /sys/class/drm/card1/card1-HDMI-A-2/status)
+
+# Check if either HDMI port is connected
+if [[ "$status_port1" == "connected" || "$status_port2" == "connected" ]]; then
+        /usr/bin/systemctl start start-xserver.service
+else
+        /usr/bin/systemctl stop start-xserver.service
+fi

--- a/ansible/roles/common/tasks/desktop.yml
+++ b/ansible/roles/common/tasks/desktop.yml
@@ -1,0 +1,43 @@
+# Used to install all the necessary packages and prepare the system to launch X
+# Server + Firefox everytime an HDMI decive is connected
+#
+- name: "Install X server and FireFox"
+  apt:
+    update_cache: yes
+    name:
+      - xorg
+      - openbox
+      - firefox-esr
+    state: present
+
+- name: "Copy service file to start the X"
+  ansible.builtin.template:
+    src: "start-xserver.service.j2"
+    dest: "/etc/systemd/system/start-xserver.service"
+    mode: "0755"
+
+- name: Reload systemd daemon
+  systemd:
+    daemon-reload: yes
+
+- name: Copy Script to launch the X when the HDMI is detected
+  ansible.builtin.copy:
+    src: "roles/common/files/x_server/hdmi_connect_script.sh"
+    dest: /usr/local/bin/
+    mode: "+x"
+
+- name: Copy the autostart file to launch FireFox when the X are started
+  ansible.builtin.copy:
+    src: "roles/common/files/x_server/firefox-autostart.desktop"
+    dest: /etc/xdg/autostart/
+
+- name: Add udev rule
+  lineinfile:
+    path: /etc/udev/rules.d/99-hdmi.rules
+    line: 'SUBSYSTEM=="drm", ACTION=="change", ENV{HOTPLUG}=="1", RUN+="/usr/local/bin/hdmi_connect_script.sh"'
+    create: true
+
+- name: Reload udev
+  systemd:
+    name: systemd-udevd
+    state: restarted

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -45,5 +45,8 @@
 # firewall - setup firewall
 - include_tasks: firewall.yml
 
+# offline_redirection - setup offline redirections
+- include_tasks: offline_redirection.yml
+
 # release file 
 - include_tasks: release.yml

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -27,6 +27,9 @@
 # webserver - install offline coding systems
 - include_tasks: coding_systems.yml
 
+# X Server
+- include_tasks: desktop.yml
+
 # fdroid - install fdroid
 - include_tasks: fdroid.yml
 

--- a/ansible/roles/common/tasks/moodle.yml
+++ b/ansible/roles/common/tasks/moodle.yml
@@ -23,6 +23,7 @@
     force: yes
     depth: 1
     accept_hostkey: true
+  become: true
 
 - name: Download moosh | Moodle Shell
   ansible.builtin.unarchive:

--- a/ansible/roles/common/tasks/offline_redirection.yml
+++ b/ansible/roles/common/tasks/offline_redirection.yml
@@ -1,0 +1,12 @@
+- name: Copy the internet connection check script
+  ansible.builtin.copy:
+    src: "check_internet_connection.sh"
+    dest: "/usr/local/bin/check_internet.sh"
+    mode: "u+x"
+
+- name: Add cron task to check internet connection
+  ansible.builtin.cron:
+    name: "check_internet"
+    minute: "*"
+    job: "/usr/local/bin/check_internet.sh"
+    user: "root"

--- a/ansible/roles/common/templates/start-xserver.service.j2
+++ b/ansible/roles/common/templates/start-xserver.service.j2
@@ -1,0 +1,10 @@
+[Unit]
+Description=Start X server for Firefox
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/startx -- /usr/bin/X :1 -logfile /var/log/xorg.log
+Restart=always
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
With this change, every-time a HDMI device is detected, Xorg is started and using Openbox, a lightweight window manager, we launch Firefox with the elimupi.online page.

When the HDMI device is disconnected, everything is shout down so there is no CPU or Memory usage.

The idea is to be able to use the Raspberry Pi as desktop computer with a projector, screen or so.

#37 