### PR TITLE
Feature/116 Fix for the date of the wiki files

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -161,8 +161,8 @@ kiwix_directory_mode: "0755"
 
 kiwix_version: kiwix-tools_linux-armhf-3.4.0
 # below doens't yet work correct as on day 31 you get the day 1 of that month
-vikidia_version: "vikidia_en_all_nopic_{{ lookup('pipe','date -d \"last month\" +%Y-%m') }}"
-wiktionary_version: "wiktionary_en_simple_all_nopic_{{ lookup('pipe','date -d \"last month\" +%Y-%m') }}"
+vikidia_version: "vikidia_en_all_nopic_{{ lookup('pipe','date -d \"2 month ago\" +%Y-%m 2> /dev/null || date -v-2m +%Y-%m') }}"
+wiktionary_version: "wiktionary_en_simple_all_nopic_{{ lookup('pipe','date -d \"2 month ago\" +%Y-%m 2> /dev/null || date -v-2m +%Y-%m') }}"
 
 
 ansible_host_key_checking: false


### PR DESCRIPTION
The files for previous month are still not available:
- https://ftp.nluug.nl/pub/kiwix/zim/vikidia/vikidia_en_all_nopic_2023-10.zim
 so we are taking them for 2 months ago now.
I also added a fallback for MacOS since `date -d` is not available:
```
➜ ~ date -d "2 month ago" +%Y-%m
date: illegal option -- d
usage: date [-jnRu] [-I[date|hours|minutes|seconds]] [-f input_fmt]
            [-r filename|seconds] [-v[+|-]val[y|m|w|d|H|M|S]]
            [[[[mm]dd]HH]MM[[cc]yy][.SS] | new_date] [+output_fmt]

➜ ~ date -d "2 month ago" +%Y-%m 2> /dev/null || date -v-2m +%Y-%m
2023-09
```

#116 