### PR TITLE
Using a disk image in Ext4 to store the logs

### DIFF
--- a/ansible/roles/common/files/nginx/admin.local
+++ b/ansible/roles/common/files/nginx/admin.local
@@ -3,7 +3,7 @@ server {
     listen [::]:80;
     server_name admin.local www.admin.local admin.elimupi.online local.elimupi.online;
     index index.php index.html index.htm;
-        error_log               /var/www/log/admin-log;
+        error_log               /mnt/content/www_log/admin-log;
 
     location / {
         autoindex on;

--- a/ansible/roles/common/files/nginx/fdroid.local
+++ b/ansible/roles/common/files/nginx/fdroid.local
@@ -2,7 +2,7 @@ server {
 	listen 80;
 	listen [::]:80;
 	server_name fdroid.elimupi.online  www.fdroid.local fdroid.local;
-	error_log 		/var/www/log/fdroid-log;
+	error_log 		/mnt/content/www_log/fdroid-log;
 	location /{
 		autoindex on;
 		root /mnt/content/fdroid;

--- a/ansible/roles/common/files/nginx/files.local
+++ b/ansible/roles/common/files/nginx/files.local
@@ -1,7 +1,7 @@
 server {
 	listen        	80;    
 	server_name		www.files.local files.local;
-	error_log 		/var/www/log/files-log;
+	error_log 		/mnt/content/www_log/files-log;
 	location /{
 		autoindex on;
 		root /mnt/content/files;

--- a/ansible/roles/common/tasks/setup.yml
+++ b/ansible/roles/common/tasks/setup.yml
@@ -40,6 +40,12 @@
     regexp: '^LABEL=Content'
     line: 'LABEL=Content /mnt/content ntfs defaults,noatime,nofail 0 0'
 
+- name: Setup | Add the logs image to fstab
+  ansible.builtin.lineinfile:
+    path: /etc/fstab
+    regexp: 'www_log'
+    line: '/mnt/content/www_log.img /mnt/content/www_log ext4 defaults,noatime,nofail 0 0'
+
 - name: Setup | Install devmon.service systemd unit file
   ansible.builtin.template:
     src: devmon.service.j2

--- a/ansible/roles/common/tasks/webserver.yml
+++ b/ansible/roles/common/tasks/webserver.yml
@@ -28,12 +28,6 @@
     path: /etc/nginx/sites-enabled/default
     state: absent
 
-- name: Webserver | Create  directory /var/www/log
-  ansible.builtin.file:
-    path: /var/www/log
-    state: directory
-    mode: '0755'
-
 - name: Webserver | Enable services
   ansible.builtin.service:
     name: "{{ item }}"
@@ -95,6 +89,18 @@
     path: /etc/nginx/nginx.conf
     regex: '^\s*#? *server_names_hash_bucket_size 64;'
     line: server_names_hash_bucket_size 64;
+
+- name: Webserver | set access_log to the mounted device
+  ansible.builtin.lineinfile:
+    path: /etc/nginx/nginx.conf
+    regexp: 'access_log\s+/var/log/nginx/access.log;$'
+    line: 'access_log /mnt/content/www_log/access.log;'
+
+- name: Webserver | set error_log to the mounted device
+  ansible.builtin.lineinfile:
+    path: /etc/nginx/nginx.conf
+    regexp: 'error_log /var/log/nginx/error.log;$'
+    line: 'error_log /mnt/content/www_log/error.log;'
 
 # Add Webinterface sudo settings
 - name: Webserver | Set sudo file 020_elimupi


### PR DESCRIPTION
Note that before merging the diff I will upload to the content disk files the image, the image is created with:
```
dd if=/dev/zero of=/mnt/content/www_log.img bs=10M count=10
mkfs.ext4 /mnt/content/www_log.img
```
Using this image we can keep inside the NTFS volume a Ext4 with permissions that will allow log rotation and so on, this will also prevent flooding the root volume with logs. The image size is 100MB that should be enough for this.

This is how it looks like:
```
pi@elimupi:/mnt/content/www_log $ df -h
Filesystem      Size  Used Avail Use% Mounted on
/dev/root       118G  9.8G  103G   9% /
devtmpfs        1.7G     0  1.7G   0% /dev
tmpfs           1.9G     0  1.9G   0% /dev/shm
tmpfs           759M  1.3M  758M   1% /run
tmpfs           5.0M  4.0K  5.0M   1% /run/lock
/dev/mmcblk0p1  255M   91M  164M  36% /boot
/dev/sda3       466G  348G  119G  75% /mnt/content
/dev/loop0       92M   32K   85M   1% /mnt/content/www_log
/dev/sda1       197M  2.0K  197M   1% /media/pi/EFI
tmpfs           380M  4.0K  380M   1% /run/user/1000
pi@elimupi:/mnt/content/www_log $ ls
access.log  admin-log  error.log  fdroid-log  files-log  lost+found
```

#33 