### PR TITLE
chore: pin roles and collections to versions compatible with ansible core 2.10

### DIFF
--- a/ansible/collections.yml
+++ b/ansible/collections.yml
@@ -1,4 +1,6 @@
 ---
 collections:
   - name: community.mysql
+    version: 3.8.0
   - name: community.general
+    version: 7.5.9

--- a/ansible/roles.yml
+++ b/ansible/roles.yml
@@ -1,5 +1,9 @@
 - src: singleplatform-eng.users
+  version: v1.2.6
 - src: ajsalminen.hosts
-- src: Oefenweb.dnsmasq 
+- src: Oefenweb.dnsmasq
+  version: v2.2.31
 - src: geerlingguy.mysql
+  version: 4.3.5
 - src: veselahouba.openldap
+  version: 2.0.1


### PR DESCRIPTION
This took a lot of time to get right on a recent distro. Newer version of the roles/collections don't work with ansible-core 2.10 anymore.