### PR TITLE
feat: add leaphy easybloqs offline application

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -335,3 +335,4 @@ squid_ssl_cert_path: "/etc/squid/squid.pem"
 leaphy_frontend_version: 3.4.0
 leaphy_arduino_cli_version: 1.2.0
 leaphy_avr_platform_version: 1.8.6
+leaphy_backend_version: v1.7.5

--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -27,6 +27,7 @@ hosts_default_ipv4_hosts:
     - admin.elimupi.online
     - scratch.elimupi.online
     - registration.elimupi.online
+    - leaphy.elimupi.online
 
 dean_api_host: "DEANVPN001.elimupi.dean"
 dean_api_basepath: "/api/connect"
@@ -207,7 +208,7 @@ kiwix_version: kiwix-tools_linux-armhf-3.4.0
 #vikidia_version: "vikidia_en_all_nopic_{{ lookup('pipe','date -d \"$(date +%Y-%m-4) -4 month\" +%Y-%m || date -v -4m +%Y-%m') }}"
 #wiktionary_version: "wiktionary_en_simple_all_nopic_{{ lookup('pipe','date -d \"$(date +%Y-%m-2) -2 month\" +%Y-%m || date -v -4m +%Y-%m') }}"
 vikidia_version: "vikidia_en_all_nopic_2023-08"
-wiktionary_version: "wiktionary_en_simple_all_nopic_2024-06"
+wiktionary_version: "wiktionary_en_simple_all_nopic_2025-04"
 
 ansible_host_key_checking: false
 
@@ -329,3 +330,8 @@ openvpn_key_dir: /etc/openvpn/keys
 # Squid log dir
 squid_log_dir: /var/log/squid
 squid_ssl_cert_path: "/etc/squid/squid.pem"
+
+# Leaphy
+leaphy_frontend_version: 3.4.0
+leaphy_arduino_cli_version: 1.2.0
+leaphy_avr_platform_version: 1.8.6

--- a/ansible/playbook-elimupi.yml
+++ b/ansible/playbook-elimupi.yml
@@ -5,10 +5,5 @@
   vars:
   roles:
     - singleplatform-eng.users
-    - role: ajsalminen.hosts
-      hosts_additional_hosts:
-          - address: '10.254.252.1'
-            hostnames:
-                - DEANVPN001.elimupi.dean
     - Oefenweb.dnsmasq
     - common

--- a/ansible/roles.yml
+++ b/ansible/roles.yml
@@ -1,5 +1,4 @@
 - src: singleplatform-eng.users
-- src: ajsalminen.hosts
-- src: Oefenweb.dnsmasq 
+- src: Oefenweb.dnsmasq
 - src: geerlingguy.mysql
 - src: veselahouba.openldap

--- a/ansible/roles/common/files/leaphy/backend-env
+++ b/ansible/roles/common/files/leaphy/backend-env
@@ -1,0 +1,3 @@
+ARDUINO_CLI_PATH=/var/www/leaphy/arduino-cli
+groq_api_key=notset
+library_index_refresh_interval=0

--- a/ansible/roles/common/files/leaphy/leaphy-backend.service
+++ b/ansible/roles/common/files/leaphy/leaphy-backend.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Leaphy Backend
+After=network.target
+
+[Service]
+User=root
+ExecStart=/var/www/leaphy/backend/start.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target

--- a/ansible/roles/common/files/leaphy/start-backend.sh
+++ b/ansible/roles/common/files/leaphy/start-backend.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+cd /var/www/leaphy/backend || exit
+. /var/www/leaphy/backend/venv/bin/activate
+
+export ARDUINO_DIRECTORIES_USER="/mnt/content/leaphy/user"
+export ARDUINO_DIRECTORIES_DATA="/mnt/content/leaphy/data"
+export ARDUINO_DIRECTORIES_DOWNLOADS="/mnt/content/leaphy/tmp"
+
+exec python3 -m uvicorn --host 127.0.0.1 --port 8001 main:app

--- a/ansible/roles/common/files/nginx/leaphy.local
+++ b/ansible/roles/common/files/nginx/leaphy.local
@@ -1,0 +1,36 @@
+server {
+    listen 80;
+
+	server_name     leaphy.elimupi.online leaphy.local;
+	error_log 		/var/www/log/leaphy-log;
+
+    location ~ "^/compile|^/minify|^/ai" {
+        proxy_read_timeout 300s;
+        proxy_pass http://127.0.0.1:8001;
+    }
+
+	location / {
+		autoindex on;
+		root /var/www/leaphy/html;
+	}
+}
+
+server {
+    listen 8443 ssl;
+
+    ssl_certificate /etc/squid/squid.pem;
+    ssl_certificate_key /etc/squid/squid.pem;
+
+	server_name     leaphy.elimupi.online leaphy.local;
+	error_log 		/var/www/log/leaphy-log;
+
+    location ~ "^/compile|^/minify|^/ai" {
+        proxy_read_timeout 300s;
+        proxy_pass http://127.0.0.1:8001;
+    }
+
+	location / {
+		autoindex on;
+		root /var/www/leaphy/html;
+	}
+}

--- a/ansible/roles/common/files/nginx/leaphy.local
+++ b/ansible/roles/common/files/nginx/leaphy.local
@@ -1,18 +1,10 @@
 server {
     listen 80;
 
-	server_name     leaphy.elimupi.online leaphy.local;
-	error_log 		/var/www/log/leaphy-log;
+    server_name     leaphy.elimupi.online leaphy.local;
+    error_log 		/var/www/log/leaphy-log;
 
-    location ~ "^/compile|^/minify|^/ai" {
-        proxy_read_timeout 300s;
-        proxy_pass http://127.0.0.1:8001;
-    }
-
-	location / {
-		autoindex on;
-		root /var/www/leaphy/html;
-	}
+    return      301 https://leaphy.elimupi.online:8443$request_uri;
 }
 
 server {
@@ -21,16 +13,16 @@ server {
     ssl_certificate /etc/squid/squid.pem;
     ssl_certificate_key /etc/squid/squid.pem;
 
-	server_name     leaphy.elimupi.online leaphy.local;
-	error_log 		/var/www/log/leaphy-log;
+    server_name     leaphy.elimupi.online leaphy.local;
+    error_log 		/var/www/log/leaphy-log;
 
     location ~ "^/compile|^/minify|^/ai" {
         proxy_read_timeout 300s;
         proxy_pass http://127.0.0.1:8001;
     }
 
-	location / {
-		autoindex on;
-		root /var/www/leaphy/html;
-	}
+    location / {
+        autoindex on;
+        root /var/www/leaphy/html;
+    }
 }

--- a/ansible/roles/common/files/nginx/leaphy.local
+++ b/ansible/roles/common/files/nginx/leaphy.local
@@ -10,8 +10,8 @@ server {
 server {
     listen 8443 ssl;
 
-    ssl_certificate /etc/squid/squid.pem;
-    ssl_certificate_key /etc/squid/squid.pem;
+    ssl_certificate /etc/ssl/certs/leaphy.pem;
+    ssl_certificate_key /etc/ssl/private/leaphy.key;
 
     server_name     leaphy.elimupi.online leaphy.local;
     error_log 		/var/www/log/leaphy-log;

--- a/ansible/roles/common/tasks/iptables.yml
+++ b/ansible/roles/common/tasks/iptables.yml
@@ -62,6 +62,18 @@
     - 172.16.0.0/12
     - 192.168.0.0/16
 
+- name: Allow https on 8443
+  ansible.builtin.iptables:
+    chain: INPUT
+    protocol: tcp
+    destination_port: '8443'
+    source: '{{ item }}'
+    jump: ACCEPT
+  loop:
+    - 10.0.0.0/8
+    - 172.16.0.0/12
+    - 192.168.0.0/16
+
 - name: Allow Kolibri
   ansible.builtin.iptables:
     chain: INPUT

--- a/ansible/roles/common/tasks/leaphy.yml
+++ b/ansible/roles/common/tasks/leaphy.yml
@@ -6,7 +6,10 @@
     dest: /etc/nginx/sites-available/leaphy.local
   notify:
     - Restart Nginx
-  tags: leaphy
+
+- name: Leaphy | Generate a Self Signed OpenSSL certificate
+  ansible.builtin.shell: |
+    openssl req -new -newkey rsa:4096 -days 9999 -nodes -x509 -subj "/C=NL/ST=Utrecht/L=Amersfoort/O=Leaphy/CN=leaphy.elimupi.online" -keyout /etc/ssl/private/leaphy.key -out /etc/ssl/certs/leaphy.pem
 
 - name: Leaphy | Enable nginx configuration
   ansible.builtin.file:
@@ -17,7 +20,6 @@
     state: link
   notify:
     - Restart Nginx
-  tags: leaphy
 
 - name: Leaphy | Create app directories
   ansible.builtin.file:
@@ -27,7 +29,6 @@
   loop:
     - /var/www/leaphy/html
     - /var/www/leaphy/backend
-  tags: leaphy
 
 - name: Leaphy | Download frontend files
   ansible.builtin.unarchive:
@@ -39,13 +40,13 @@
   git:
     repo: "https://github.com/leaphy-robotics/leaphy-webbased-backend.git"
     dest: "/var/www/leaphy/backend"
+    version: "{{ leaphy_backend_version }}"
     force: true
 
 - name: Leaphy | Create backend settings
   ansible.builtin.copy:
     src: leaphy/backend-env
     dest: /var/www/leaphy/backend/.env
-  tags: leaphy
 
 - name: Leaphy | Download arduino CLI
   ansible.builtin.unarchive:
@@ -58,7 +59,6 @@
     python3 -m venv /var/www/leaphy/backend/venv
     . /var/www/leaphy/backend/venv/bin/activate
     pip3 install -r /var/www/leaphy/backend/requirements.txt
-  tags: leaphy
 
 - name: Leaphy | Create arduino directories
   ansible.builtin.file:
@@ -71,7 +71,6 @@
     - /mnt/content/leaphy/data
     - /mnt/content/leaphy/user
     - /mnt/content/leaphy/tmp
-  tags: leaphy
 
 - name: Leaphy | Install AVR platform and libraries
   command: "/var/www/leaphy/arduino-cli {{ item }}"
@@ -95,21 +94,18 @@
     - lib install "Adafruit SGP30 Sensor"
     - lib install "Adafruit LSM9DS1 Library"
     - lib install "Adafruit SSD1306"
-  tags: leaphy
 
 - name: Leaphy | Install backend start script
   ansible.builtin.copy:
     src: leaphy/start-backend.sh
     dest: /var/www/leaphy/backend/start.sh
     mode: "0775"
-  tags: leaphy
 
 - name: Leaphy | Create systemd service
   ansible.builtin.copy:
     src: leaphy/leaphy-backend.service
     dest: /etc/systemd/system/leaphy-backend.service
     mode: "0664"
-  tags: leaphy
 
 - name: Leaphy | Enable and start the backend
   ansible.builtin.systemd_service:
@@ -117,4 +113,3 @@
     daemon_reload: true
     state: started
     enabled: true
-  tags: leaphy

--- a/ansible/roles/common/tasks/leaphy.yml
+++ b/ansible/roles/common/tasks/leaphy.yml
@@ -1,0 +1,120 @@
+---
+# Install Leaphy Easybloqs web interface
+- name: Leaphy | Install nginx configuration
+  ansible.builtin.copy:
+    src: "nginx/leaphy.local"
+    dest: /etc/nginx/sites-available/leaphy.local
+  notify:
+    - Restart Nginx
+  tags: leaphy
+
+- name: Leaphy | Enable nginx configuration
+  ansible.builtin.file:
+    src: /etc/nginx/sites-available/leaphy.local
+    dest: /etc/nginx/sites-enabled/leaphy.local
+    owner: root
+    group: root
+    state: link
+  notify:
+    - Restart Nginx
+  tags: leaphy
+
+- name: Leaphy | Create app directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - /var/www/leaphy/html
+    - /var/www/leaphy/backend
+  tags: leaphy
+
+- name: Leaphy | Download frontend files
+  ansible.builtin.unarchive:
+    src: https://leaphyeasybloqs.com/downloads/leaphyeasybloqs-v{{ leaphy_frontend_version }}.zip
+    dest: /var/www/leaphy/html
+    remote_src: yes
+
+- name: Leaphy | Clone backend files
+  git:
+    repo: "https://github.com/leaphy-robotics/leaphy-webbased-backend.git"
+    dest: "/var/www/leaphy/backend"
+    force: true
+
+- name: Leaphy | Create backend settings
+  ansible.builtin.copy:
+    src: leaphy/backend-env
+    dest: /var/www/leaphy/backend/.env
+  tags: leaphy
+
+- name: Leaphy | Download arduino CLI
+  ansible.builtin.unarchive:
+    src: https://downloads.arduino.cc/arduino-cli/arduino-cli_{{ leaphy_arduino_cli_version }}_Linux_ARM64.tar.gz
+    dest: "/var/www/leaphy/"
+    remote_src: yes
+
+- name: Leaphy | Create backend venv
+  shell: |
+    python3 -m venv /var/www/leaphy/backend/venv
+    . /var/www/leaphy/backend/venv/bin/activate
+    pip3 install -r /var/www/leaphy/backend/requirements.txt
+  tags: leaphy
+
+- name: Leaphy | Create arduino directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+    owner: "{{ httpd_owner }}"
+  loop:
+    - /mnt/content/leaphy
+    - /mnt/content/leaphy/data
+    - /mnt/content/leaphy/user
+    - /mnt/content/leaphy/tmp
+  tags: leaphy
+
+- name: Leaphy | Install AVR platform and libraries
+  command: "/var/www/leaphy/arduino-cli {{ item }}"
+  environment:
+    ARDUINO_DIRECTORIES_USER: "/mnt/content/leaphy/user"
+    ARDUINO_DIRECTORIES_DATA: "/mnt/content/leaphy/data"
+    ARDUINO_DIRECTORIES_DOWNLOADS: "/mnt/content/leaphy/tmp"
+  loop:
+    - core install arduino:avr@{{ leaphy_avr_platform_version }}
+    - lib update-index
+    - lib install "Leaphy Extensions"
+    - lib install "Servo"
+    - lib install "List"
+    - lib install "Adafruit NeoPixel"
+    - lib install "Arduino_APDS9960"
+    - lib install "QMC5883LCompass"
+    - lib install "DS3231"
+    - lib install "TM1637"
+    - lib install "Adafruit BMP280 Library"
+    - lib install "Adafruit_VL53L0X"
+    - lib install "Adafruit SGP30 Sensor"
+    - lib install "Adafruit LSM9DS1 Library"
+    - lib install "Adafruit SSD1306"
+  tags: leaphy
+
+- name: Leaphy | Install backend start script
+  ansible.builtin.copy:
+    src: leaphy/start-backend.sh
+    dest: /var/www/leaphy/backend/start.sh
+    mode: "0775"
+  tags: leaphy
+
+- name: Leaphy | Create systemd service
+  ansible.builtin.copy:
+    src: leaphy/leaphy-backend.service
+    dest: /etc/systemd/system/leaphy-backend.service
+    mode: "0664"
+  tags: leaphy
+
+- name: Leaphy | Enable and start the backend
+  ansible.builtin.systemd_service:
+    name: leaphy-backend.service
+    daemon_reload: true
+    state: started
+    enabled: true
+  tags: leaphy

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -56,5 +56,8 @@
 # firewall - setup firewall
 - include_tasks: iptables.yml
 
+# leaphy - install leaphy easybloqs
+- include_tasks: leaphy.yml
+
 # reboot
 - include_tasks: reboot.yml

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -57,7 +57,11 @@
 - include_tasks: iptables.yml
 
 # leaphy - install leaphy easybloqs
-- include_tasks: leaphy.yml
+- include_tasks:
+    file: leaphy.yml
+    apply:
+      tags: leaphy
+  tags: leaphy
 
 # reboot
 - include_tasks: reboot.yml

--- a/ansible/roles/common/tasks/setup.yml
+++ b/ansible/roles/common/tasks/setup.yml
@@ -22,6 +22,24 @@
     src: "ssh_config"
     dest: "/root/.ssh/config"
 
+- name: Setup | Add localhost hosts entry
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: '^127.0.0.1 .*'
+    line: '127.0.0.1 localhost'
+
+- name: Setup | Add VPN hosts entry
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    regexp: '^10.254.252.1.*DEANVPN001.elimupi.dean'
+    line: '10.254.252.1 DEANVPN001.elimupi.dean'
+
+- name: Setup | Add web hosts entry
+  ansible.builtin.lineinfile:
+    path: /etc/hosts
+    line: "{{ host_ipv4_ipaddress }} {{ hosts_default_ipv4_hosts.hostnames | join(' ') }}"
+    regexp: "^{{ host_ipv4_ipaddress }} .*"
+
 - name: Install locales
   community.general.locale_gen:
     name: "{{ item }}"


### PR DESCRIPTION
Some comments:
- The application requires HTTPS (the WebSerial API is only available in secure contexts, we use it to upload code to robots). Since squid intercepts traffic at port 443, I've chosen to add a port 8443 for easybloqs. The cert used is a self-signed cert and will give a warning in the browser. Better ideas to fix this are welcome.
- The wiktionary version in the playbook no longer exists so I've bumped the version
- The ajsalminen.hosts role no longer worked with the ansible version shipped with ubuntu 24.04 because it uses include, which no longer exists. I've removed the role and added 3 'lineinfile' commands to replace its functionality
