### PR TITLE
fix: pin c++ library versions to prevent future breakage

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -326,7 +326,21 @@ squid_log_dir: /var/log/squid
 squid_ssl_cert_path: "/etc/squid/squid.pem"
 
 # Leaphy
-leaphy_frontend_version: 3.4.0
+leaphy_frontend_version: 3.5.0
 leaphy_arduino_cli_version: 1.2.0
 leaphy_avr_platform_version: 1.8.6
 leaphy_backend_version: v1.7.5
+leaphy_cpp_libraries:
+  - "Leaphy Extensions@1.2.0"
+  - "Servo@1.2.2"
+  - "ESP32Servo@3"
+  - "Adafruit GFX Library@1.12"
+  - "Adafruit SSD1306@2.5"
+  - "Adafruit LSM9DS1 Library@2.2.1"
+  - "Adafruit Unified Sensor@1.1.15"
+  - "List@3.0.1"
+  - "Adafruit SGP30 Sensor@2.0.3"
+  - "Adafruit_VL53L0X@1.2.4"
+  - "Adafruit BMP280 Library@2.6.8"
+  - "DS3231@1.1.2"
+  - "Adafruit LSM6DS@4.7.4"

--- a/ansible/roles/common/tasks/leaphy.yml
+++ b/ansible/roles/common/tasks/leaphy.yml
@@ -21,6 +21,11 @@
   notify:
     - Restart Nginx
 
+- name: Leaphy | Delete frontend files
+  ansible.builtin.file:
+    state: absent
+    path: /var/www/leaphy/html
+
 - name: Leaphy | Create app directories
   ansible.builtin.file:
     path: "{{ item }}"
@@ -72,7 +77,7 @@
     - /mnt/content/leaphy/user
     - /mnt/content/leaphy/tmp
 
-- name: Leaphy | Install AVR platform and libraries
+- name: Leaphy | Install AVR platform
   command: "/var/www/leaphy/arduino-cli {{ item }}"
   environment:
     ARDUINO_DIRECTORIES_USER: "/mnt/content/leaphy/user"
@@ -81,19 +86,14 @@
   loop:
     - core install arduino:avr@{{ leaphy_avr_platform_version }}
     - lib update-index
-    - lib install "Leaphy Extensions"
-    - lib install "Servo"
-    - lib install "List"
-    - lib install "Adafruit NeoPixel"
-    - lib install "Arduino_APDS9960"
-    - lib install "QMC5883LCompass"
-    - lib install "DS3231"
-    - lib install "TM1637"
-    - lib install "Adafruit BMP280 Library"
-    - lib install "Adafruit_VL53L0X"
-    - lib install "Adafruit SGP30 Sensor"
-    - lib install "Adafruit LSM9DS1 Library"
-    - lib install "Adafruit SSD1306"
+
+- name: Leaphy | Install C++ libraries
+  command: "/var/www/leaphy/arduino-cli lib install '{{ item }}'"
+  environment:
+    ARDUINO_DIRECTORIES_USER: "/mnt/content/leaphy/user"
+    ARDUINO_DIRECTORIES_DATA: "/mnt/content/leaphy/data"
+    ARDUINO_DIRECTORIES_DOWNLOADS: "/mnt/content/leaphy/tmp"
+  loop: "{{ leaphy_cpp_libraries }}"
 
 - name: Leaphy | Install backend start script
   ansible.builtin.copy:


### PR DESCRIPTION
fix: empty frontend files dir before extracting new files