### PR TITLE
chore: add a script that re-installs all arduino requirements

### DIFF
--- a/ansible/roles/common/tasks/leaphy.yml
+++ b/ansible/roles/common/tasks/leaphy.yml
@@ -101,6 +101,12 @@
     dest: /var/www/leaphy/backend/start.sh
     mode: "0775"
 
+- name: Leaphy | Install arduino platform install script
+  ansible.builtin.template:
+    src: install_arduino.sh.j2
+    dest: /var/www/leaphy/backend/install_arduino.sh
+    mode: "0775"
+
 - name: Leaphy | Create systemd service
   ansible.builtin.copy:
     src: leaphy/leaphy-backend.service

--- a/ansible/roles/common/templates/install_arduino.sh.j2
+++ b/ansible/roles/common/templates/install_arduino.sh.j2
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+
+export ARDUINO_DIRECTORIES_USER="/mnt/content/leaphy/user"
+export ARDUINO_DIRECTORIES_DATA="/mnt/content/leaphy/data"
+export ARDUINO_DIRECTORIES_DOWNLOADS="/mnt/content/leaphy/tmp"
+
+# Install the AVR platform
+/var/www/leaphy/arduino-cli core install arduino:avr@{{ leaphy_avr_platform_version }}
+/var/www/leaphy/arduino-cli lib update-index
+
+# Install required c++ libraries
+{% for library in leaphy_cpp_libraries -%}
+/var/www/leaphy/arduino-cli lib install '{{ library }}'
+{% endfor %}


### PR DESCRIPTION
In case the content disk is replaced/lost/emptied, this script will re-install all arduino tools and libs on the disk.