### PR TITLE
fix: move arduino compiler and libs to the SD card

### DIFF
--- a/ansible/group_vars/all/vars.yml
+++ b/ansible/group_vars/all/vars.yml
@@ -338,3 +338,4 @@ leaphy_cpp_libraries:
   - "Adafruit BMP280 Library@2.6.8"
   - "DS3231@1.1.2"
   - "Adafruit LSM6DS@4.7.4"
+leaphy_arduino_dir: /var/www/leaphy/arduino

--- a/ansible/roles/common/files/leaphy/start-backend.sh
+++ b/ansible/roles/common/files/leaphy/start-backend.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env sh
-cd /var/www/leaphy/backend || exit
-. /var/www/leaphy/backend/venv/bin/activate
-
-export ARDUINO_DIRECTORIES_USER="/mnt/content/leaphy/user"
-export ARDUINO_DIRECTORIES_DATA="/mnt/content/leaphy/data"
-export ARDUINO_DIRECTORIES_DOWNLOADS="/mnt/content/leaphy/tmp"
-
-exec python3 -m uvicorn --host 127.0.0.1 --port 8001 main:app

--- a/ansible/roles/common/tasks/leaphy.yml
+++ b/ansible/roles/common/tasks/leaphy.yml
@@ -111,5 +111,5 @@
   ansible.builtin.systemd:
     name: leaphy-backend.service
     daemon_reload: true
-    state: started
+    state: restarted
     enabled: true

--- a/ansible/roles/common/tasks/leaphy.yml
+++ b/ansible/roles/common/tasks/leaphy.yml
@@ -72,17 +72,17 @@
     mode: '0755'
     owner: "{{ httpd_owner }}"
   loop:
-    - /mnt/content/leaphy
-    - /mnt/content/leaphy/data
-    - /mnt/content/leaphy/user
-    - /mnt/content/leaphy/tmp
+    - "{{ leaphy_arduino_dir }}"
+    - "{{ leaphy_arduino_dir }}/data"
+    - "{{ leaphy_arduino_dir }}/user"
+    - "{{ leaphy_arduino_dir }}/tmp"
 
 - name: Leaphy | Install AVR platform
   command: "/var/www/leaphy/arduino-cli {{ item }}"
   environment:
-    ARDUINO_DIRECTORIES_USER: "/mnt/content/leaphy/user"
-    ARDUINO_DIRECTORIES_DATA: "/mnt/content/leaphy/data"
-    ARDUINO_DIRECTORIES_DOWNLOADS: "/mnt/content/leaphy/tmp"
+    ARDUINO_DIRECTORIES_USER: "{{ leaphy_arduino_dir }}/user"
+    ARDUINO_DIRECTORIES_DATA: "{{ leaphy_arduino_dir }}/data"
+    ARDUINO_DIRECTORIES_DOWNLOADS: "{{ leaphy_arduino_dir }}/tmp"
   loop:
     - core install arduino:avr@{{ leaphy_avr_platform_version }}
     - lib update-index
@@ -90,14 +90,14 @@
 - name: Leaphy | Install C++ libraries
   command: "/var/www/leaphy/arduino-cli lib install '{{ item }}'"
   environment:
-    ARDUINO_DIRECTORIES_USER: "/mnt/content/leaphy/user"
-    ARDUINO_DIRECTORIES_DATA: "/mnt/content/leaphy/data"
-    ARDUINO_DIRECTORIES_DOWNLOADS: "/mnt/content/leaphy/tmp"
+    ARDUINO_DIRECTORIES_USER: "{{ leaphy_arduino_dir }}/user"
+    ARDUINO_DIRECTORIES_DATA: "{{ leaphy_arduino_dir }}/data"
+    ARDUINO_DIRECTORIES_DOWNLOADS: "{{ leaphy_arduino_dir }}/tmp"
   loop: "{{ leaphy_cpp_libraries }}"
 
 - name: Leaphy | Install backend start script
-  ansible.builtin.copy:
-    src: leaphy/start-backend.sh
+  ansible.builtin.template:
+    src: start-leaphy-backend.sh.j2
     dest: /var/www/leaphy/backend/start.sh
     mode: "0775"
 

--- a/ansible/roles/common/templates/start-leaphy-backend.sh.j2
+++ b/ansible/roles/common/templates/start-leaphy-backend.sh.j2
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+cd /var/www/leaphy/backend || exit
+. /var/www/leaphy/backend/venv/bin/activate
+
+export ARDUINO_DIRECTORIES_USER="{{ leaphy_arduino_dir }}/user"
+export ARDUINO_DIRECTORIES_DATA="{{ leaphy_arduino_dir }}/data"
+export ARDUINO_DIRECTORIES_DOWNLOADS="{{ leaphy_arduino_dir }}/tmp"
+
+exec python3 -m uvicorn --host 127.0.0.1 --port 8001 main:app


### PR DESCRIPTION
Placing it on the Content disk gave some issues when the disk was moved/damaged/replaced. This way everything just works and keeps working from the SD.